### PR TITLE
Fix GitHub Actions helm test failures

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Run test cases with Kind cluster
       run: |
-        make helmE2ETestPreProd
+        make helmE2ETestLocal
 
     - name: Terminate Kind cluster
       if: always()

--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ kind-export-logs:
 .PHONY: deploy-cert-manager
 deploy-cert-manager: ## Deploy cert-manager in the configured Kubernetes cluster in ~/.kube/config
 	helm repo add jetstack https://charts.jetstack.io --force-update
-	helm install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION} --set crds.enabled=true --set config.apiVersion=controller.config.cert-manager.io/v1alpha1 --set config.kind=ControllerConfiguration --set config.kubernetesAPIQPS=10000 --set config.kubernetesAPIBurst=10000 --kubeconfig=${TEST_KUBECONFIG_LOCATION}
+	helm upgrade --install cert-manager jetstack/cert-manager --namespace cert-manager --create-namespace --version ${CERT_MANAGER_VERSION} --set crds.enabled=true --set config.apiVersion=controller.config.cert-manager.io/v1alpha1 --set config.kind=ControllerConfiguration --set config.kubernetesAPIQPS=10000 --set config.kubernetesAPIBurst=10000 --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 	kubectl wait --for=condition=Available --timeout=300s apiservice v1.cert-manager.io --kubeconfig=${TEST_KUBECONFIG_LOCATION}
 
 .PHONY: install-local


### PR DESCRIPTION
- Fix workflow to use correct Makefile target (helmE2ETestLocal instead of helmE2ETestPreProd)
- Fix deploy-cert-manager to use 'helm upgrade --install' instead of 'helm install' to handle existing installations gracefully

These changes resolve the 'cannot re-use a name that is still in use' error that was causing GitHub Actions tests to fail.

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->

### Description of changes

<!--
What code changes did you make?
Have you made any important design decisions?
What use cases does this change enable?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced ? -->

### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

