### PR TITLE
test: verify trivy-pr workflow fires on PR events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # Build the manager binary
+# (test edit to validate Trivy PR workflow — will be reverted)
 FROM --platform=${BUILDPLATFORM} golang:1.26 as builder
 WORKDIR /workspace
 


### PR DESCRIPTION
Throwaway PR to exercise the `pull_request` trigger path on `.github/workflows/trivy-pr.yml`. Will be closed once the check completes.